### PR TITLE
Level filter

### DIFF
--- a/CanOpener.lua
+++ b/CanOpener.lua
@@ -34,6 +34,13 @@ local function slashHandler(msg)
 			CanOpenerGlobal.PosOrNegColor(CanOpenerSavedVars.remixEpicGems, "will", "will not") ..
 			" be combined higher than Epic");
 		CanOpenerGlobal.DebugLog("slashHandler - End Remix Gems Level");
+	elseif (command == "levelrestricted") then
+        CanOpenerGlobal.DebugLog("slashHandler - Start Level Restricted");
+        CanOpenerSavedVars.showLevelRestrictedItems = not CanOpenerSavedVars.showLevelRestrictedItems;
+        CanOpenerGlobal.ForceButtonRefresh();
+        CanOpenerGlobal.CanOut(": Level-Restricted Items " ..
+            CanOpenerGlobal.PosOrNegColor(CanOpenerSavedVars.showLevelRestrictedItems, "will", "will not") .. " be shown");
+        CanOpenerGlobal.DebugLog("slashHandler - End Level Restricted");
 	elseif (command == "reset") then
 		CanOpenerGlobal.DebugLog("slashHandler - Start Reset");
 		CanOpenerGlobal.CanOut(": Resetting settings and position.");
@@ -71,22 +78,24 @@ local function slashHandler(msg)
 		CanOpenerGlobal.CanOut(CanOpenerSavedVars.excludedItems);
 		CanOpenerGlobal.DebugLog("slashHandler - End Ignore List");
 	else
-		CanOpenerGlobal.DebugLog("slashHandler - Unknown command " .. (command or "<None>"));
-		CanOpenerGlobal.CanOut("Commands for |cffffa500/CanOpener|r :");
-		local rousingState = CanOpenerGlobal.PosOrNegColor(CanOpenerSavedVars.showRousing, "On", "Off");
-		CanOpenerGlobal.CanOut("  |cffffa500 rousing|r - Toggle showing Elemental Rousings (" .. rousingState .. ")");
-		if (CanOpenerGlobal.IsRemixActive) then
-			local remixGemsState = CanOpenerGlobal.PosOrNegColor(CanOpenerSavedVars.showRemixGems, "On", "Off");
-			CanOpenerGlobal.CanOut("  |cffffa500 remixGem|r - Toggle showing Remix Gems (" .. remixGemsState .. ")");
-			local remixEpicGemsState = CanOpenerGlobal.PosOrNegColor(CanOpenerSavedVars.remixEpicGems, "On", "Off");
-			CanOpenerGlobal.CanOut("  |cffffa500 remixEpicGems|r - Toggle combining gems higher than Epic (" ..
-				remixEpicGemsState .. ")");
-		end
-		CanOpenerGlobal.CanOut("  |cffffa500 ignore|r <itemID> - Ignore a specific item")
-        CanOpenerGlobal.CanOut("  |cffffa500 unignore|r <itemID> - Remove an item from the ignore list")
-        CanOpenerGlobal.CanOut("  |cffffa500 list|r - Show ignored items")
-		CanOpenerGlobal.CanOut("  |cffffa500 reset|r - Reset all settings!");
-	end
+        CanOpenerGlobal.DebugLog("slashHandler - Unknown command " .. (command or "<None>"));
+        CanOpenerGlobal.CanOut("Commands for |cffffa500/CanOpener|r :");
+        local rousingState = CanOpenerGlobal.PosOrNegColor(CanOpenerSavedVars.showRousing, "On", "Off");
+        CanOpenerGlobal.CanOut("  |cffffa500 rousing|r - Toggle showing Elemental Rousings (" .. rousingState .. ")");
+        if (CanOpenerGlobal.IsRemixActive) then
+            local remixGemsState = CanOpenerGlobal.PosOrNegColor(CanOpenerSavedVars.showRemixGems, "On", "Off");
+            CanOpenerGlobal.CanOut("  |cffffa500 remixGem|r - Toggle showing Remix Gems (" .. remixGemsState .. ")");
+            local remixEpicGemsState = CanOpenerGlobal.PosOrNegColor(CanOpenerSavedVars.remixEpicGems, "On", "Off");
+            CanOpenerGlobal.CanOut("  |cffffa500 remixEpicGems|r - Toggle combining gems higher than Epic (" ..
+                remixEpicGemsState .. ")");
+        end
+        local levelRestrictedState = CanOpenerGlobal.PosOrNegColor(CanOpenerSavedVars.showLevelRestrictedItems, "On", "Off");
+        CanOpenerGlobal.CanOut("  |cffffa500 levelrestricted|r - Toggle showing level-restricted items (" .. levelRestrictedState .. ")");
+        CanOpenerGlobal.CanOut("  |cffffa500 ignore|r <itemID> - Ignore a specific item");
+        CanOpenerGlobal.CanOut("  |cffffa500 unignore|r <itemID> - Remove an item from the ignore list");
+        CanOpenerGlobal.CanOut("  |cffffa500 list|r - Show ignored items");
+        CanOpenerGlobal.CanOut("  |cffffa500 reset|r - Reset all settings!");
+    end
 	CanOpenerGlobal.DebugLog("slashHandler - End");
 end
 
@@ -223,7 +232,7 @@ local UpdateButtons = function()
 			if itemID and cacheDetails and not cacheDetails.lockbox and not onExcludeList then
 				local count = C_Item.GetItemCount(itemID);
 
-				if CanOpenerGlobal.CriteriaContext:evaluateAll(cacheDetails, count) and not itemIDsInQueue[itemID] then
+				if CanOpenerGlobal.CriteriaContext:evaluateAll(itemID, cacheDetails, count) and not itemIDsInQueue[itemID] then
 					table.insert(buttonQueue, itemID)
 					itemIDsInQueue[itemID] = true
 				end

--- a/CanOpener.toc
+++ b/CanOpener.toc
@@ -1,6 +1,6 @@
 ## Interface: 110100, 110105
 ## Title: Can Opener
-## Version: 1.0.63
+## Version: 1.0.64
 ## Author: Jassade
 ## Notes: Adds a movable button to easily open items in your bag!
 ## SavedVariablesPerCharacter: CanOpenerSavedVars

--- a/CanOpener.toc
+++ b/CanOpener.toc
@@ -1,6 +1,6 @@
 ## Interface: 110100, 110105
 ## Title: Can Opener
-## Version: 1.0.58
+## Version: 1.0.63
 ## Author: Jassade
 ## Notes: Adds a movable button to easily open items in your bag!
 ## SavedVariablesPerCharacter: CanOpenerSavedVars

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -9,3 +9,5 @@
 1.0.60 - Adding Ignore List
 1.0.61 - Added items from 11.0.7 - 11.1.0
 1.0.62 - Added more items from 11.1.0 - 11.1.5 and bumped TOC
+1.0.63 - Added LevelRequirementStrategy to suppress items based on level requirements.
+         Updated slash commands and settings menu to toggle level-restricted items.

--- a/Criteria.lua
+++ b/Criteria.lua
@@ -11,7 +11,7 @@ function CriteriaStrategy:new()
     return instance
 end
 
-function CriteriaStrategy:evaluate(cacheDetails, count)
+function CriteriaStrategy:evaluate(itemID, cacheDetails, count)
     error("This method should be overridden in the derived class")
 end
 
@@ -23,9 +23,9 @@ function CriteriaContext:new(strategies)
     return instance
 end
 
-function CriteriaContext:evaluateAll(cacheDetails, count)
+function CriteriaContext:evaluateAll(itemID, cacheDetails, count)
     for _, strategy in ipairs(self.strategies) do
-        if strategy:evaluate(cacheDetails, count) then
+        if strategy:evaluate(itemID, cacheDetails, count) then
             return false
         end
     end
@@ -40,7 +40,7 @@ function SkipRousingStrategy:new()
     return instance
 end
 
-function SkipRousingStrategy:evaluate(cacheDetails, count)
+function SkipRousingStrategy:evaluate(itemID, cacheDetails, count)
     return not CanOpenerSavedVars.showRousing and cacheDetails.isRousing
 end
 
@@ -52,7 +52,7 @@ function SkipRemixGemsStrategy:new()
     return instance
 end
 
-function SkipRemixGemsStrategy:evaluate(cacheDetails, count)
+function SkipRemixGemsStrategy:evaluate(itemID, cacheDetails, count)
     return not CanOpenerSavedVars.showRemixGems and cacheDetails.mopRemixGem
 end
 
@@ -64,7 +64,7 @@ function SkipRemixEpicGemsStrategy:new()
     return instance
 end
 
-function SkipRemixEpicGemsStrategy:evaluate(cacheDetails, count)
+function SkipRemixEpicGemsStrategy:evaluate(itemID, cacheDetails, count)
     return not CanOpenerSavedVars.remixEpicGems and cacheDetails.mopRemixEpicGem
 end
 
@@ -76,8 +76,26 @@ function ThresholdStrategy:new()
     return instance
 end
 
-function ThresholdStrategy:evaluate(cacheDetails, count)
+function ThresholdStrategy:evaluate(itemID, cacheDetails, count)
     return (cacheDetails.threshold or 1) > count
+end
+
+LevelRequirementStrategy = CriteriaStrategy:new()
+LevelRequirementStrategy.__index = LevelRequirementStrategy
+
+function LevelRequirementStrategy:new()
+    local instance = setmetatable({}, self)
+    return instance
+end
+
+function LevelRequirementStrategy:evaluate(itemID, cacheDetails, count)
+    local _,_,_,_,itemMinLevel = C_Item.GetItemInfo(itemID)
+    if not itemMinLevel then
+        -- If item info is still unavailable, return false
+        return false
+    end
+    CanOpenerGlobal.DebugLog("LevelRequirementStrategy:evaluate - itemMinLevel: " .. tostring(itemMinLevel) .. ", playerLevel: " .. tostring(UnitLevel("player")))
+    return not CanOpenerSavedVars.showLevelRestrictedItems and itemMinLevel > UnitLevel("player")
 end
 
 -- Create instances of strategies
@@ -85,6 +103,7 @@ local skipRousingStrategy = SkipRousingStrategy:new()
 local skipRemixGemsStrategy = SkipRemixGemsStrategy:new()
 local skipRemixEpicGemsStrategy = SkipRemixEpicGemsStrategy:new()
 local thresholdStrategy = ThresholdStrategy:new()
+local levelRequirementStrategy = LevelRequirementStrategy:new()
 
 -- Add strategies to context
 local strategies = {
@@ -95,5 +114,7 @@ if CanOpenerGlobal.IsRemixActive then
     strategies.insert(2, skipRemixGemsStrategy)
     strategies.insert(3, skipRemixEpicGemsStrategy)
 end
+
+table.insert(strategies, levelRequirementStrategy)
 
 CanOpenerGlobal.CriteriaContext = CriteriaContext:new(strategies)

--- a/Criteria.lua
+++ b/Criteria.lua
@@ -11,7 +11,7 @@ function CriteriaStrategy:new()
     return instance
 end
 
-function CriteriaStrategy:evaluate(itemID, cacheDetails, count)
+function CriteriaStrategy:shouldFilter(itemID, cacheDetails, count)
     error("This method should be overridden in the derived class")
 end
 
@@ -25,7 +25,7 @@ end
 
 function CriteriaContext:evaluateAll(itemID, cacheDetails, count)
     for _, strategy in ipairs(self.strategies) do
-        if strategy:evaluate(itemID, cacheDetails, count) then
+        if strategy:shouldFilter(itemID, cacheDetails, count) then
             return false
         end
     end
@@ -40,7 +40,7 @@ function SkipRousingStrategy:new()
     return instance
 end
 
-function SkipRousingStrategy:evaluate(itemID, cacheDetails, count)
+function SkipRousingStrategy:shouldFilter(itemID, cacheDetails, count)
     return not CanOpenerSavedVars.showRousing and cacheDetails.isRousing
 end
 
@@ -52,7 +52,7 @@ function SkipRemixGemsStrategy:new()
     return instance
 end
 
-function SkipRemixGemsStrategy:evaluate(itemID, cacheDetails, count)
+function SkipRemixGemsStrategy:shouldFilter(itemID, cacheDetails, count)
     return not CanOpenerSavedVars.showRemixGems and cacheDetails.mopRemixGem
 end
 
@@ -64,7 +64,7 @@ function SkipRemixEpicGemsStrategy:new()
     return instance
 end
 
-function SkipRemixEpicGemsStrategy:evaluate(itemID, cacheDetails, count)
+function SkipRemixEpicGemsStrategy:shouldFilter(itemID, cacheDetails, count)
     return not CanOpenerSavedVars.remixEpicGems and cacheDetails.mopRemixEpicGem
 end
 
@@ -76,7 +76,7 @@ function ThresholdStrategy:new()
     return instance
 end
 
-function ThresholdStrategy:evaluate(itemID, cacheDetails, count)
+function ThresholdStrategy:shouldFilter(itemID, cacheDetails, count)
     return (cacheDetails.threshold or 1) > count
 end
 
@@ -88,13 +88,13 @@ function LevelRequirementStrategy:new()
     return instance
 end
 
-function LevelRequirementStrategy:evaluate(itemID, cacheDetails, count)
+function LevelRequirementStrategy:shouldFilter(itemID, cacheDetails, count)
     local _,_,_,_,itemMinLevel = C_Item.GetItemInfo(itemID)
     if not itemMinLevel then
         -- If item info is still unavailable, return false
         return false
     end
-    CanOpenerGlobal.DebugLog("LevelRequirementStrategy:evaluate - itemMinLevel: " .. tostring(itemMinLevel) .. ", playerLevel: " .. tostring(UnitLevel("player")))
+    CanOpenerGlobal.DebugLog("LevelRequirementStrategy:shouldFilter - itemMinLevel: " .. tostring(itemMinLevel) .. ", playerLevel: " .. tostring(UnitLevel("player")))
     return not CanOpenerSavedVars.showLevelRestrictedItems and itemMinLevel > UnitLevel("player")
 end
 

--- a/Helpers.lua
+++ b/Helpers.lua
@@ -126,7 +126,7 @@ local function initSavedVariables()
 		showRousing = true,
 		showRemixGems = true,
 		remixEpicGems = true,
-		showLevelRestrictedItems = true, -- Add this line
+		showLevelRestrictedItems = true,
 		position = { "CENTER", "CENTER", 0, 0 },
 		excludedItems = { },
 	};

--- a/Helpers.lua
+++ b/Helpers.lua
@@ -126,6 +126,7 @@ local function initSavedVariables()
 		showRousing = true,
 		showRemixGems = true,
 		remixEpicGems = true,
+		showLevelRestrictedItems = true, -- Add this line
 		position = { "CENTER", "CENTER", 0, 0 },
 		excludedItems = { },
 	};

--- a/Menu.lua
+++ b/Menu.lua
@@ -31,6 +31,33 @@ function InitSettingsMenu()
         Settings.CreateCheckbox(category, setting, tooltip)
     end
 
+    do
+        local variable = "showLevelRestrictedItems"
+        local name = "Show Level-Restricted Items"
+        local tooltip = "If Checked, items with a level requirement higher than your character's level will be shown."
+        local defaultValue = true
+
+        local function GetValue()
+            return CanOpenerSavedVars.showLevelRestrictedItems
+        end
+
+        local function SetValue(value)
+            CanOpenerSavedVars.showLevelRestrictedItems = value
+        end
+
+        local setting = Settings.RegisterProxySetting(
+            category,
+            "CanOpener_" .. variable,
+            Settings.VarType.Boolean,
+            name,
+            defaultValue,
+            GetValue,
+            SetValue
+        )
+
+        Settings.CreateCheckbox(category, setting, tooltip)
+    end
+
     if (CanOpenerGlobal.IsRemixActive) then
         do
             local variable = "showRemixGems"

--- a/README.md
+++ b/README.md
@@ -5,22 +5,28 @@ Adds buttons for items that can be opened, learned, etc. Very small and responsi
 - Movable button (Hold right click and drag)
 - Automatically adds items as they get looted
 - Hides in combat
-- Character specific settings
+- Character-specific settings
 - Lightweight
-- Low memory foot print
+- Low memory footprint
+- Ability to suppress items based on level requirements
+- Ignore list for specific items
 
-# Chat commands
-Use `/co` or `/canopener` followed by a command
-- `rousing` This will toggle showing Rousing elements
-- `remixgem` This will toggle showing Remix Gems
-- `remixepicgems` Toggle combining gems higher than Epic
-- `reset` This will reset the addon to the default settings
+# Chat Commands
+Use `/co` or `/canopener` followed by a command:
+- `rousing` - Toggle showing Rousing elements
+- `remixgem` - Toggle showing Remix Gems
+- `remixepicgems` - Toggle combining gems higher than Epic
+- `levelrestricted` - Toggle showing level-restricted items
+- `ignore <itemID>` - Add an item to the ignore list
+- `unignore <itemID>` - Remove an item from the ignore list
+- `list` - Show all ignored items
+- `reset` - Reset the addon to the default settings
 
 **NOTE:** Remix options are only active while the event is, otherwise they will not show up.
 
 # Missing Items
-To request adding any missing items open an issue or make a Pull Request. 
+To request adding any missing items, open an issue or make a Pull Request.
 
 # Planned Upgrades
 - Localizations
-- Ability to add/ignore items to show
+- Enhanced UI for managing ignored items


### PR DESCRIPTION
This pull request introduces a new feature to suppress items based on level requirements, along with several code refactors and updates to improve functionality and user experience. The most important changes include adding a new `LevelRequirementStrategy`, updating slash commands and settings to toggle level-restricted items, and refactoring the `Criteria` module for better extensibility.

### New Feature: Level-Restricted Items
* Added a `LevelRequirementStrategy` to filter items based on their level requirements (`Criteria.lua`). [[1]](diffhunk://#diff-1e897010d3bbc9d3454989475c68ea6ade2583bbd6c14ea4555d1c00a973c055L79-R106) [[2]](diffhunk://#diff-1e897010d3bbc9d3454989475c68ea6ade2583bbd6c14ea4555d1c00a973c055R118-R119)
* Introduced a new slash command `/co levelrestricted` to toggle the display of level-restricted items (`CanOpener.lua`). [[1]](diffhunk://#diff-768b7eb2414d8be8885c587f49a1edca26c8903cae7b12c67d9f2e15f252142fR37-R43) [[2]](diffhunk://#diff-768b7eb2414d8be8885c587f49a1edca26c8903cae7b12c67d9f2e15f252142fL85-R96)
* Updated the settings menu with a checkbox to enable or disable showing level-restricted items (`Menu.lua`).
* Added a new saved variable `showLevelRestrictedItems` to persist the user's preference (`Helpers.lua`).